### PR TITLE
- `:value` key should pass-through to the underlying fields

### DIFF
--- a/lib/localized_fields/form_builder.rb
+++ b/lib/localized_fields/form_builder.rb
@@ -38,12 +38,12 @@ module LocalizedFields
 
         value = translations.has_key?(language.to_s) ? translations[language.to_s] : nil
 
-        options = options.merge(value: value, id: "#{object_name}_#{attribute}_translations_#{language}", name: "#{object_name}[#{attribute}_translations][#{language}]")
+        options = options.merge(id: "#{object_name}_#{attribute}_translations_#{language}", name: "#{object_name}[#{attribute}_translations][#{language}]")
       else
         value = @object ? @object[attribute.to_s] : nil
-
-        options = options.merge(value: value)
       end
+
+      options[:value] ||= value || ''
 
       return attribute, options
     end

--- a/spec/localized_fields_spec.rb
+++ b/spec/localized_fields_spec.rb
@@ -27,11 +27,11 @@ describe 'LocalizedFields' do
 
       expected =  %{<dl class="field">}
       expected <<  %{<dt><label for="post_title_translations_en">Title</label></dt>}
-      expected <<  %{<dd><input id="post_title_translations_en" name="post[title_translations][en]" type="text" /></dd>}
+      expected <<  %{<dd><input id="post_title_translations_en" name="post[title_translations][en]" value="" type="text" /></dd>}
       expected << %{</dl>}
       expected << %{<dl class="field">}
       expected <<  %{<dt><label for="post_title_translations_pt">Title</label></dt>}
-      expected <<  %{<dd><input id="post_title_translations_pt" name="post[title_translations][pt]" type="text" /></dd>}
+      expected <<  %{<dd><input id="post_title_translations_pt" name="post[title_translations][pt]" value="" type="text" /></dd>}
       expected << %{</dl>}
 
       expect(output).to eq(expected)
@@ -42,8 +42,8 @@ describe 'LocalizedFields' do
           %{<div>#{localized_field.text_field(:title).html_safe}</div>}.html_safe
       end
 
-      expected =  %{<div><input id="post_title_translations_en" name="post[title_translations][en]" type="text" /></div>}
-      expected << %{<div><input id="post_title_translations_pt" name="post[title_translations][pt]" type="text" /></div>}
+      expected =  %{<div><input id="post_title_translations_en" name="post[title_translations][en]" value="" type="text" /></div>}
+      expected << %{<div><input id="post_title_translations_pt" name="post[title_translations][pt]" value="" type="text" /></div>}
 
       expect(output).to eq(expected)
     end
@@ -53,7 +53,7 @@ describe 'LocalizedFields' do
           %{<div>#{localized_field.text_field(:en).html_safe}</div>}.html_safe
       end
 
-      expected = %{<div><input type="text" name="post[title_translations][en]" id="post_title_translations_en" /></div>}
+      expected = %{<div><input value="" type="text" name="post[title_translations][en]" id="post_title_translations_en" /></div>}
 
       expect(output).to eq(expected)
     end
@@ -131,7 +131,7 @@ describe 'LocalizedFields' do
         localized_field.text_field :en
       end
 
-      expected = %{<input type="text" name="post[title_translations][en]" id="post_title_translations_en" />}
+      expected = %{<input value="" type="text" name="post[title_translations][en]" id="post_title_translations_en" />}
 
       expect(output).to eq(expected)
     end
@@ -141,8 +141,8 @@ describe 'LocalizedFields' do
         localized_field.text_field :title
       end
 
-      expected =  %{<input id="post_title_translations_en" name="post[title_translations][en]" type="text" />}
-      expected << %{<input id="post_title_translations_pt" name="post[title_translations][pt]" type="text" />}
+      expected =  %{<input id="post_title_translations_en" name="post[title_translations][en]" value="" type="text" />}
+      expected << %{<input id="post_title_translations_pt" name="post[title_translations][pt]" value="" type="text" />}
 
       expect(output).to eq(expected)
     end
@@ -152,21 +152,58 @@ describe 'LocalizedFields' do
         localized_field.text_field :title, class: 'field'
       end
 
-      expected =  %{<input class="field" id="post_title_translations_en" name="post[title_translations][en]" type="text" />}
-      expected << %{<input class="field" id="post_title_translations_pt" name="post[title_translations][pt]" type="text" />}
+      expected =  %{<input class="field" id="post_title_translations_en" name="post[title_translations][en]" value="" type="text" />}
+      expected << %{<input class="field" id="post_title_translations_pt" name="post[title_translations][pt]" value="" type="text" />}
 
       expect(output).to eq(expected)
+    end
+
+    context 'post with values' do
+      before do
+        post.stub(:title_translations).and_return({ 'en' => 'title en', 'pt' => 'title pt' })
+      end
+
+      it 'returns a text_area tag for en' do
+        output = builder.localized_fields(:title) do |localized_field|
+          localized_field.text_field :en
+        end
+
+        expected =  %{<input value="title en" type="text" name="post[title_translations][en]" id="post_title_translations_en" />}
+
+        expect(output).to eq(expected)
+      end
+
+      it 'returns a text_area tag for ja' do
+        output = builder.localized_fields(:title) do |localized_field|
+          localized_field.text_field :ja
+        end
+
+        expected =  %{<input value="" type="text" name="post[title_translations][ja]" id="post_title_translations_ja" />}
+
+        expect(output).to eq(expected)
+      end
+
+      it 'returns a text_area tag for all languages' do
+        output = builder.localized_fields do |localized_field|
+          localized_field.text_field :title
+        end
+
+        expected =  %{<input id="post_title_translations_en" name="post[title_translations][en]" value="title en" type="text" />}
+        expected << %{<input id="post_title_translations_pt" name="post[title_translations][pt]" value="title pt" type="text" />}
+
+        expect(output).to eq(expected)
+      end
     end
   end
 
   describe 'text_area' do
     it 'returns a text_area tag for en' do
       output = builder.localized_fields(:title) do |localized_field|
-        localized_field.text_area :en, value: 'text'
+        localized_field.text_area :en, value: 'My Value'
       end
 
       expected =  %{<textarea name="post[title_translations][en]" id="post_title_translations_en">\n}
-      expected << %{</textarea>}
+      expected << %{My Value</textarea>}
 
       expect(output).to eq(expected)
     end
@@ -208,6 +245,17 @@ describe 'LocalizedFields' do
         end
 
         expected =  %{<textarea name="post[title_translations][en]" id="post_title_translations_en">\ntitle en}
+        expected << %{</textarea>}
+
+        expect(output).to eq(expected)
+      end
+
+      it 'returns a text_area tag for ja' do
+        output = builder.localized_fields(:title) do |localized_field|
+          localized_field.text_area :ja
+        end
+
+        expected =  %{<textarea name="post[title_translations][ja]" id="post_title_translations_ja">\n}
         expected << %{</textarea>}
 
         expect(output).to eq(expected)


### PR DESCRIPTION
if there is no value in the hash (in other words, it becomes a "default value" for unspecified locales)

- fix error when value is missing from underlying value set for a given locale, by setting value to "" when not present in hash.